### PR TITLE
GitHub public release v1.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+## [1.1.10] - 2022-10-17
+
+### Added
+- Support API Key authentication
+- Support Show ByteHouse table keys
+- Add virtual warehouse name settings
+
+### Changed
+- Upgrade JWT version to v3.19.2
+- Refactor serializable character set
+- Update Volcano region name to CN-BEIJING
+- Update License header to include claims
+
+### Fixed
+- Fix Datatype serialization issues
+- Fix UInt64 lexer for parsing
+- Fix insertion query for Nullable array datatype
+
 ## [1.1.1] - 2022-03-24
 
 ### Changed

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -11,7 +11,7 @@
 
     <module name="Header">
         <property name="headerFile" value="${checkstyle.header.file}"/>
-        <property name="ignoreLines" value="2,3,4,5,6,7"/>
+        <property name="ignoreLines" value="2,3,4,5,6,7,8,9"/>
         <property name="fileExtensions" value="java"/>
     </module>
 

--- a/config/checkstyle/license.header
+++ b/config/checkstyle/license.header
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/build.gradle
+++ b/driver/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'com.bytedance.bytehouse'
-version = '1.1.9'
+version = '1.1.10'
 description 'ByteHouse JDBC Driver'
 
 java {

--- a/driver/build.gradle
+++ b/driver/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'com.bytedance.bytehouse'
-version = '1.1.0'
+version = '1.1.2'
 description 'ByteHouse JDBC Driver'
 
 java {

--- a/driver/build.gradle
+++ b/driver/build.gradle
@@ -34,7 +34,8 @@ repositories {
 dependencies {
     implementation "io.airlift:aircompressor:0.18" // for LZ4 compression logic
     implementation "org.roaringbitmap:RoaringBitmap:0.9.15" // for BitMap datatype implementation
-    implementation 'com.auth0:java-jwt:3.18.2'
+    implementation 'com.auth0:java-jwt:3.19.2'
+    implementation group: 'org.json', name: 'json', version: '20210307'
     compileOnly "org.slf4j:slf4j-api:1.7.30"
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 

--- a/driver/build.gradle
+++ b/driver/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'com.bytedance.bytehouse'
-version = '1.1.2'
+version = '1.1.9'
 description 'ByteHouse JDBC Driver'
 
 java {

--- a/driver/src/main/java/com/bytedance/bytehouse/annotation/Issue.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/annotation/Issue.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/buffer/BuffedReader.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/buffer/BuffedReader.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/buffer/BuffedWriter.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/buffer/BuffedWriter.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/buffer/ByteArrayWriter.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/buffer/ByteArrayWriter.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/buffer/CompressedBuffedReader.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/buffer/CompressedBuffedReader.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/buffer/CompressedBuffedWriter.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/buffer/CompressedBuffedWriter.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/buffer/SocketBuffedReader.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/buffer/SocketBuffedReader.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/buffer/SocketBuffedWriter.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/buffer/SocketBuffedWriter.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/client/ClientContext.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/client/ClientContext.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/client/NativeClient.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/client/NativeClient.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/client/NativeContext.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/client/NativeContext.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/client/ServerContext.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/client/ServerContext.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/client/SessionState.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/client/SessionState.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/AbstractColumn.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/AbstractColumn.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/Block.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/Block.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/BlockSettings.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/BlockSettings.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/Column.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/Column.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/ColumnArray.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/ColumnArray.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/ColumnFactoryUtils.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/ColumnFactoryUtils.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/ColumnLowCardinality.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/ColumnLowCardinality.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/ColumnMap.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/ColumnMap.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/ColumnNullable.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/ColumnNullable.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/ColumnNullable.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/ColumnNullable.java
@@ -56,6 +56,10 @@ public class ColumnNullable extends AbstractColumn {
             serializer.writeByte(sign);
         }
 
+        if (data instanceof ColumnArray) {
+            ((ColumnArray) data).flushOffsets(serializer);
+        }
+
         if (immediate)
             buffer.writeTo(serializer);
     }

--- a/driver/src/main/java/com/bytedance/bytehouse/data/ColumnTuple.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/ColumnTuple.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/ColumnWriterBuffer.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/ColumnWriterBuffer.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/DataTypeConverter.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/DataTypeConverter.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/DataTypeFactory.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/DataTypeFactory.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/IColumn.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/IColumn.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/IDataType.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/IDataType.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/IDataType.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/IDataType.java
@@ -20,6 +20,7 @@ import com.bytedance.bytehouse.misc.SQLLexer;
 import com.bytedance.bytehouse.serde.BinaryDeserializer;
 import com.bytedance.bytehouse.serde.BinarySerializer;
 import java.io.IOException;
+import java.io.Serializable;
 import java.sql.SQLException;
 import java.time.ZoneId;
 
@@ -29,7 +30,7 @@ import java.time.ZoneId;
  * @param <CK>   Java class the ByteHouse data type will be internally represented as.
  * @param <JDBC> Main JDBC type the CK Java class will be converted to and fro.
  */
-public interface IDataType<CK, JDBC> {
+public interface IDataType<CK, JDBC> extends Serializable {
 
     /**
      * Returns ByteHouse data type name.

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/BaseDataTypeInt.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/BaseDataTypeInt.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/BaseDataTypeInt16.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/BaseDataTypeInt16.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/BaseDataTypeInt32.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/BaseDataTypeInt32.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/BaseDataTypeInt64.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/BaseDataTypeInt64.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/BaseDataTypeInt8.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/BaseDataTypeInt8.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeBitMap64.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeBitMap64.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeDate.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeDate.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeFloat32.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeFloat32.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeFloat64.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeFloat64.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeIPv4.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeIPv4.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeIPv6.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeIPv6.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeInt16.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeInt16.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeInt32.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeInt32.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeInt64.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeInt64.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeInt8.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeInt8.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeUInt16.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeUInt16.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeUInt32.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeUInt32.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeUInt64.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeUInt64.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeUInt64.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeUInt64.java
@@ -78,7 +78,7 @@ public class DataTypeUInt64 implements BaseDataTypeInt64<BigInteger, BigInteger>
 
     @Override
     public BigInteger deserializeText(SQLLexer lexer) throws SQLException {
-        return BigInteger.valueOf(lexer.numberLiteral().longValue());
+        return lexer.bigIntegerLiteral();
     }
 
     @Override

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeUInt8.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeUInt8.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeUUID.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/DataTypeUUID.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/SerializableCharset.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/SerializableCharset.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/SerializableCharset.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/SerializableCharset.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bytedance.bytehouse.data.type;
+
+import java.io.Serializable;
+import java.nio.charset.Charset;
+import java.util.Objects;
+
+public class SerializableCharset implements Serializable {
+
+    private transient Charset charset;
+
+    private final String charsetStr;
+
+    public SerializableCharset(Charset charset) {
+        Objects.requireNonNull(charset);
+        this.charset = charset;
+        this.charsetStr = charset.toString();
+    }
+
+    public Charset get() {
+        if (charset == null) {
+            this.charset = Charset.forName(charsetStr);
+        }
+        return this.charset;
+    }
+}

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/SerializableCharset.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/SerializableCharset.java
@@ -13,26 +13,22 @@
  */
 package com.bytedance.bytehouse.data.type;
 
-import java.io.Serializable;
+import com.bytedance.bytehouse.io.StringBasedSerializable;
 import java.nio.charset.Charset;
-import java.util.Objects;
 
-public class SerializableCharset implements Serializable {
+public class SerializableCharset extends StringBasedSerializable<Charset> {
 
-    private transient Charset charset;
-
-    private final String charsetStr;
-
-    public SerializableCharset(Charset charset) {
-        Objects.requireNonNull(charset);
-        this.charset = charset;
-        this.charsetStr = charset.toString();
+    public SerializableCharset(final Charset charset) {
+        super(charset);
     }
 
-    public Charset get() {
-        if (charset == null) {
-            this.charset = Charset.forName(charsetStr);
-        }
-        return this.charset;
+    @Override
+    protected String toBackedString(Charset charset) {
+        return charset.toString();
+    }
+
+    @Override
+    protected Charset fromBackedString(String str) {
+        return Charset.forName(str);
     }
 }

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeArray.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeArray.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeCreator.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeCreator.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeDateTime.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeDateTime.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeDateTime64.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeDateTime64.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeDecimal.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeDecimal.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeEnum16.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeEnum16.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeEnum8.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeEnum8.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeFixedString.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeFixedString.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeFixedString.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeFixedString.java
@@ -15,6 +15,7 @@ package com.bytedance.bytehouse.data.type.complex;
 
 import com.bytedance.bytehouse.client.ServerContext;
 import com.bytedance.bytehouse.data.IDataType;
+import com.bytedance.bytehouse.data.type.SerializableCharset;
 import com.bytedance.bytehouse.exception.ByteHouseSQLException;
 import com.bytedance.bytehouse.misc.BytesCharSeq;
 import com.bytedance.bytehouse.misc.SQLLexer;
@@ -42,12 +43,13 @@ public class DataTypeFixedString implements IDataType<CharSequence, String> {
 
     private final String defaultValue;
 
-    private final Charset charset;
+    private final SerializableCharset serializableCharset;
 
     public DataTypeFixedString(String name, int n, ServerContext serverContext) {
         this.n = n;
         this.name = name;
-        this.charset = serverContext.getConfigure().charset();
+        Charset charset = serverContext.getConfigure().charset();
+        this.serializableCharset = new SerializableCharset(charset);
 
         byte[] data = new byte[n];
         for (int i = 0; i < n; i++) {
@@ -96,7 +98,7 @@ public class DataTypeFixedString implements IDataType<CharSequence, String> {
         if (data instanceof BytesCharSeq) {
             writeBytes((((BytesCharSeq) data).bytes()), serializer);
         } else {
-            writeBytes(data.toString().getBytes(charset), serializer);
+            writeBytes(data.toString().getBytes(this.serializableCharset.get()), serializer);
         }
     }
 
@@ -116,7 +118,8 @@ public class DataTypeFixedString implements IDataType<CharSequence, String> {
 
     @Override
     public String deserializeBinary(BinaryDeserializer deserializer) throws SQLException, IOException {
-        return new String(deserializer.readBytes(n), charset);
+        byte[] bs = deserializer.readBytes(n);
+        return new String(bs, this.serializableCharset.get());
     }
 
     @Override

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeLowCardinality.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeLowCardinality.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeMap.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeMap.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeNothing.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeNothing.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeNullable.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeNullable.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeString.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeString.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeString.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeString.java
@@ -14,6 +14,7 @@
 package com.bytedance.bytehouse.data.type.complex;
 
 import com.bytedance.bytehouse.data.IDataType;
+import com.bytedance.bytehouse.data.type.SerializableCharset;
 import com.bytedance.bytehouse.exception.ByteHouseSQLException;
 import com.bytedance.bytehouse.misc.BytesCharSeq;
 import com.bytedance.bytehouse.misc.SQLLexer;
@@ -29,10 +30,10 @@ public class DataTypeString implements IDataType<CharSequence, String> {
 
     public static final DataTypeCreator<CharSequence, String> CREATOR = (lexer, serverContext) -> new DataTypeString(serverContext.getConfigure().charset());
 
-    private final Charset charset;
+    private final SerializableCharset serializableCharset;
 
     public DataTypeString(Charset charset) {
-        this.charset = charset;
+        this.serializableCharset = new SerializableCharset(charset);
     }
 
     @Override
@@ -75,7 +76,7 @@ public class DataTypeString implements IDataType<CharSequence, String> {
         if (data instanceof BytesCharSeq) {
             serializer.writeBytesBinary(((BytesCharSeq) data).bytes());
         } else {
-            serializer.writeStringBinary(data.toString(), charset);
+            serializer.writeStringBinary(data.toString(), this.serializableCharset.get());
         }
     }
 
@@ -86,7 +87,7 @@ public class DataTypeString implements IDataType<CharSequence, String> {
     @Override
     public String deserializeBinary(BinaryDeserializer deserializer) throws SQLException, IOException {
         byte[] bs = deserializer.readBytesBinary();
-        return new String(bs, charset);
+        return new String(bs, this.serializableCharset.get());
     }
 
     @Override

--- a/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeTuple.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/data/type/complex/DataTypeTuple.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/exception/ByteHouseClientException.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/exception/ByteHouseClientException.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/exception/ByteHouseException.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/exception/ByteHouseException.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/exception/ByteHouseSQLException.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/exception/ByteHouseSQLException.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/exception/InvalidOperationException.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/exception/InvalidOperationException.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/exception/InvalidValueException.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/exception/InvalidValueException.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/exception/NoDefaultValueException.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/exception/NoDefaultValueException.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/exception/NotImplementedException.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/exception/NotImplementedException.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/exception/TransactionLabelExistsException.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/exception/TransactionLabelExistsException.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/io/StringBasedSerializable.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/io/StringBasedSerializable.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/io/StringBasedSerializable.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/io/StringBasedSerializable.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bytedance.bytehouse.io;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public abstract class StringBasedSerializable<A> implements Serializable {
+
+  private transient A nonSerializable;
+
+  private final String backedString;
+
+  public StringBasedSerializable(final A nonSerializable) {
+    Objects.requireNonNull(nonSerializable);
+    this.nonSerializable = nonSerializable;
+    this.backedString = toBackedString(nonSerializable);
+  }
+
+  protected abstract String toBackedString(final A x);
+
+  protected abstract A fromBackedString(final String str);
+
+  public final A get() {
+    if (nonSerializable == null) {
+      nonSerializable = fromBackedString(backedString);
+    }
+    return nonSerializable;
+  }
+}

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseArray.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseArray.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseArray.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseArray.java
@@ -21,10 +21,11 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.StringJoiner;
 import java.util.function.BiFunction;
+import java.io.Serializable;
 
 import static com.bytedance.bytehouse.misc.PrimitiveConverter.box;
 
-public class ByteHouseArray implements SQLArray {
+public class ByteHouseArray implements SQLArray, Serializable {
 
     private static final Logger LOG = LoggerFactoryUtils.getLogger(ByteHouseArray.class);
 

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseConnection.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseConnection.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseDataSource.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseDataSource.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseDatabaseMetadata.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseDatabaseMetadata.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseDatabaseMetadata.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseDatabaseMetadata.java
@@ -1198,14 +1198,14 @@ public final class ByteHouseDatabaseMetadata implements BHDatabaseMetadata, SQLH
                             .replace("(", "")
                             .replace(")", "")
                             .split(",");
-                    for (int j = 1; j <= colNames.length; j++) {
+                    for (int j = 0; j < colNames.length; ++j) {
                         builder.addRow(
                                 catalog,
                                 schema,
                                 table,
                                 keyType,
                                 colNames[j].trim(),
-                                j
+                                j + 1
                         );
                     }
                 }

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseDatabaseMetadata.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseDatabaseMetadata.java
@@ -1124,8 +1124,17 @@ public final class ByteHouseDatabaseMetadata implements BHDatabaseMetadata, SQLH
             final String schema,
             final String table
     ) throws SQLException {
-        // FIXME: 17/8/21 check this for gateway
-        return getEmptyResultSet();
+        return getKeysFromByteHouse(
+                catalog, schema, table,
+                Arrays.asList(
+                        "PrimaryKey",
+                        "ClusterKey",
+                        "OrderByKey",
+                        "PartitionKey",
+                        "SampleKey",
+                        "UniqueKey"
+                )
+        );
     }
 
     /**
@@ -1152,6 +1161,57 @@ public final class ByteHouseDatabaseMetadata implements BHDatabaseMetadata, SQLH
     ) throws SQLException {
         // FIXME: 17/8/21 check this for gateway
         return getEmptyResultSet();
+    }
+
+    private ByteHouseResultSet getKeysFromByteHouse(
+            final String catalog,
+            final String schema,
+            final String table,
+            final List<String> keyTypes
+    ) throws SQLException {
+        final ByteHouseResultSetBuilder builder = ByteHouseResultSetBuilder
+                .builder(6, connection.serverContext())
+                .cfg(connection.cfg())
+                .columnNames(
+                        "TABLE_CAT",
+                        "TABLE_SCHEM",
+                        "TABLE_NAME",
+                        "COLUMN_TYPE",
+                        "COLUMN_NAME",
+                        "KEY_SEQ"
+                )
+                .columnTypes(
+                        "String",
+                        "String",
+                        "String",
+                        "String",
+                        "String",
+                        "String"
+                );
+
+        final String sql = String.format("SHOW TABLE KEYS `%s`.`%s`", schema, table);
+        try (ResultSet rs = request(sql)) {
+            if (rs.next()) {
+                for (String keyType: keyTypes) {
+                    String[] colNames = rs
+                            .getString(keyType)
+                            .replace("(", "")
+                            .replace(")", "")
+                            .split(",");
+                    for (int j = 1; j <= colNames.length; j++) {
+                        builder.addRow(
+                                catalog,
+                                schema,
+                                table,
+                                keyType,
+                                colNames[j].trim(),
+                                j
+                        );
+                    }
+                }
+            }
+        }
+        return builder.build();
     }
 
     /**

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseDriver.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseDriver.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseJdbcUrlParser.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseJdbcUrlParser.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseResultSet.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseResultSet.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseResultSetBuilder.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseResultSetBuilder.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseResultSetMetaData.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseResultSetMetaData.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseStruct.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseStruct.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseStruct.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/ByteHouseStruct.java
@@ -18,6 +18,7 @@ import com.bytedance.bytehouse.jdbc.wrapper.SQLStruct;
 import com.bytedance.bytehouse.log.Logger;
 import com.bytedance.bytehouse.log.LoggerFactoryUtils;
 import com.bytedance.bytehouse.misc.ValidateUtils;
+import java.io.Serializable;
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.StringJoiner;
@@ -25,7 +26,7 @@ import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class ByteHouseStruct implements SQLStruct {
+public class ByteHouseStruct implements SQLStruct, Serializable {
 
     private static final Logger LOG = LoggerFactoryUtils.getLogger(ByteHouseStruct.class);
 

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/statement/AbstractPreparedStatement.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/statement/AbstractPreparedStatement.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/statement/ByteHousePreparedInsertStatement.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/statement/ByteHousePreparedInsertStatement.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/statement/ByteHousePreparedQueryStatement.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/statement/ByteHousePreparedQueryStatement.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/statement/ByteHouseStatement.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/statement/ByteHouseStatement.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/BHConnection.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/BHConnection.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/BHDataSource.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/BHDataSource.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/BHDatabaseMetadata.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/BHDatabaseMetadata.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/SQLArray.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/SQLArray.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/SQLHelper.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/SQLHelper.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/SQLPreparedStatement.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/SQLPreparedStatement.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/SQLResultSet.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/SQLResultSet.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/SQLResultSetMetaData.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/SQLResultSetMetaData.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/SQLStatement.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/SQLStatement.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/SQLStruct.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/SQLStruct.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/SQLWrapper.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/jdbc/wrapper/SQLWrapper.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/log/FormattingTuple.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/log/FormattingTuple.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/log/InternalUtils.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/log/InternalUtils.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/log/JdkLogger.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/log/JdkLogger.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/log/JdkLoggerFactoryAdaptor.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/log/JdkLoggerFactoryAdaptor.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/log/Logger.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/log/Logger.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/log/LoggerFactoryAdaptor.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/log/LoggerFactoryAdaptor.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/log/LoggerFactoryUtils.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/log/LoggerFactoryUtils.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/log/Logging.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/log/Logging.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/log/MessageFormatter.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/log/MessageFormatter.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/log/Slf4jLogger.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/log/Slf4jLogger.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/log/Slf4jLoggerFactoryAdaptor.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/log/Slf4jLoggerFactoryAdaptor.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/AKSKTokenGeneratorWithJWT.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/AKSKTokenGeneratorWithJWT.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/ByteHouseCityHashUtils.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/ByteHouseCityHashUtils.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/BytesCharSeq.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/BytesCharSeq.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/BytesHelper.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/BytesHelper.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/CheckedIterator.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/CheckedIterator.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/CheckedSupplier.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/CheckedSupplier.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/CollectionUtil.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/CollectionUtil.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/DateTimeUtil.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/DateTimeUtil.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/ExceptionUtil.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/ExceptionUtil.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/LRUCache.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/LRUCache.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/PrimitiveConverter.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/PrimitiveConverter.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/SQLLexer.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/SQLLexer.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/SQLParserUtils.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/SQLParserUtils.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/SqlParserCaseExpressionUtils.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/SqlParserCaseExpressionUtils.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/SqlParserDateFormatUtils.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/SqlParserDateFormatUtils.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/SqlParserOrExpressionUtils.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/SqlParserOrExpressionUtils.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/StrUtil.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/StrUtil.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/StringView.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/StringView.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/Switcher.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/Switcher.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/SystemUtil.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/SystemUtil.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/misc/ValidateUtils.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/misc/ValidateUtils.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/AKSKHelloRequest.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/AKSKHelloRequest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/AggQueryPlanResponse.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/AggQueryPlanResponse.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/DataRequest.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/DataRequest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/DataResponse.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/DataResponse.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/EOFStreamResponse.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/EOFStreamResponse.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/ExceptionResponse.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/ExceptionResponse.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/ExtremesResponse.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/ExtremesResponse.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/HelloRequest.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/HelloRequest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/HelloResponse.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/HelloResponse.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/LogResponse.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/LogResponse.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/PingRequest.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/PingRequest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/PongResponse.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/PongResponse.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/ProfileInfoResponse.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/ProfileInfoResponse.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/ProgressResponse.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/ProgressResponse.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/QueryMetadataResponse.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/QueryMetadataResponse.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/QueryPlanResponse.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/QueryPlanResponse.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/QueryRequest.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/QueryRequest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/Request.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/Request.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/Response.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/Response.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/TableColumnsResponse.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/TableColumnsResponse.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/protocol/TotalsResponse.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/protocol/TotalsResponse.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/serde/BinaryDeserializer.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/serde/BinaryDeserializer.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/serde/BinarySerializer.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/serde/BinarySerializer.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/serde/SettingType.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/serde/SettingType.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/settings/BHConstants.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/settings/BHConstants.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/settings/ByteHouseConfig.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/settings/ByteHouseConfig.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/settings/ByteHouseConfig.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/settings/ByteHouseConfig.java
@@ -37,6 +37,8 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public class ByteHouseConfig implements Serializable {
 
+    private static final String apiKeyUser = "bytehouse";
+
     private final String region;
 
     private final String host;
@@ -54,6 +56,8 @@ public class ByteHouseConfig implements Serializable {
     private final String accessKey;
 
     private final String secretKey;
+
+    private final String apiKey;
 
     private final boolean isTableau;
 
@@ -91,6 +95,7 @@ public class ByteHouseConfig implements Serializable {
             final String password,
             final String accessKey,
             final String secretKey,
+            final String apiKey,
             final boolean isTableau,
             final boolean isVolcano,
             final Duration queryTimeout,
@@ -114,6 +119,7 @@ public class ByteHouseConfig implements Serializable {
         this.password = password;
         this.accessKey = accessKey;
         this.secretKey = secretKey;
+        this.apiKey = apiKey;
         this.isTableau = isTableau;
         this.isVolcano = isVolcano;
         this.queryTimeout = queryTimeout;
@@ -150,10 +156,16 @@ public class ByteHouseConfig implements Serializable {
     }
 
     public String user() {
+        if (!StrUtil.isBlank(this.apiKey)) {
+            return apiKeyUser;
+        }
         return this.user;
     }
 
     public String password() {
+        if (!StrUtil.isBlank(this.apiKey)) {
+            return this.apiKey;
+        }
         return this.password;
     }
 
@@ -163,6 +175,10 @@ public class ByteHouseConfig implements Serializable {
 
     public String secretKey() {
         return this.secretKey;
+    }
+
+    public String apiKey() {
+        return this.apiKey;
     }
 
     public boolean isTableau() {
@@ -222,6 +238,9 @@ public class ByteHouseConfig implements Serializable {
     }
 
     public String fullUsername() {
+        if (!StrUtil.isBlank(this.apiKey)) {
+            return apiKeyUser;
+        }
         if (StrUtil.isBlank(this.account)) {
             return this.user;
         }
@@ -293,6 +312,12 @@ public class ByteHouseConfig implements Serializable {
         return Builder.builder(this)
                 .accessKey(accessKey)
                 .secretKey(secretKey)
+                .build();
+    }
+
+    public ByteHouseConfig withAPIKeyCredentials(final String apiKey) {
+        return Builder.builder(this)
+                .apiKey(apiKey)
                 .build();
     }
 
@@ -446,6 +471,8 @@ public class ByteHouseConfig implements Serializable {
 
         private String secretKey;
 
+        private String apiKey;
+
         private boolean isTableau;
 
         private boolean isVolcano;
@@ -496,6 +523,7 @@ public class ByteHouseConfig implements Serializable {
                     .password(cfg.password())
                     .accessKey(cfg.accessKey())
                     .secretKey(cfg.secretKey())
+                    .apiKey(cfg.apiKey())
                     .isTableau(cfg.isTableau())
                     .isVolcano(cfg.isVolcano())
                     .queryTimeout(cfg.queryTimeout())
@@ -563,6 +591,11 @@ public class ByteHouseConfig implements Serializable {
 
         public Builder secretKey(final String secretKey) {
             this.withSetting(SettingKey.secretKey, secretKey);
+            return this;
+        }
+
+        public Builder apiKey(final String apiKey) {
+            this.withSetting(SettingKey.apiKey, apiKey);
             return this;
         }
 
@@ -661,6 +694,7 @@ public class ByteHouseConfig implements Serializable {
             this.password = (String) this.settings.getOrDefault(SettingKey.password, "");
             this.accessKey = (String) this.settings.getOrDefault(SettingKey.accessKey, "");
             this.secretKey = (String) this.settings.getOrDefault(SettingKey.secretKey, "");
+            this.apiKey = (String) this.settings.getOrDefault(SettingKey.apiKey, "");
             this.isTableau = (boolean) this.settings.getOrDefault(SettingKey.isTableau, false);
             this.isVolcano = (boolean) this.settings.getOrDefault(SettingKey.isVolcano, false);
             this.queryTimeout = (Duration) this.settings.getOrDefault(SettingKey.queryTimeout, Duration.ZERO);
@@ -687,6 +721,7 @@ public class ByteHouseConfig implements Serializable {
                     password,
                     accessKey,
                     secretKey,
+                    apiKey,
                     isTableau,
                     isVolcano,
                     queryTimeout,

--- a/driver/src/main/java/com/bytedance/bytehouse/settings/ByteHouseErrCode.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/settings/ByteHouseErrCode.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/settings/ByteHouseRegion.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/settings/ByteHouseRegion.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/settings/ByteHouseRegion.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/settings/ByteHouseRegion.java
@@ -21,7 +21,7 @@ public enum ByteHouseRegion {
     CN_NORTH_1("CN-NORTH-1", "gateway.aws-cn-north-1.bytehouse.cn", 19000),
     AP_SOUTHEAST_1("AP-SOUTHEAST-1", "gateway.aws-ap-southeast-1.bytehouse.cloud", 19000),
     BOE("BOE", "gateway.volc-boe.offline.bytehouse.cn", 19000),
-    CN_BEIJING("CN_BEIJING", "bytehouse-cn-beijing.volces.com", 19000);
+    CN_BEIJING("CN-BEIJING", "bytehouse-cn-beijing.volces.com", 19000);
 
     private final String name;
 

--- a/driver/src/main/java/com/bytedance/bytehouse/settings/ClientConfigKey.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/settings/ClientConfigKey.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/settings/SettingKey.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/settings/SettingKey.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/settings/SettingKey.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/settings/SettingKey.java
@@ -1731,6 +1731,13 @@ public class SettingKey implements Serializable {
             .build();
 
     @ClientConfigKey
+    public static SettingKey apiKey = SettingKey.builder()
+            .withName("api_key")
+            .withType(SettingType.UTF_8)
+            .isSecret()
+            .build();
+
+    @ClientConfigKey
     public static SettingKey isVolcano = SettingKey.builder()
             .withName("is_volcano")
             .withType(SettingType.BOOL)

--- a/driver/src/main/java/com/bytedance/bytehouse/settings/SettingKey.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/settings/SettingKey.java
@@ -1661,8 +1661,13 @@ public class SettingKey implements Serializable {
             .withType(SettingType.UTF_8)
             .build();
 
-    public static SettingKey virtual_warehouse = SettingKey.builder()
-            .withName("virtual_warehouse")
+    public static SettingKey vw_id = SettingKey.builder()
+            .withName("virtual_warehouse") // Taking value as virtual warehouse id
+            .withType(SettingType.UTF_8)
+            .build();
+
+    public static SettingKey vw_name = SettingKey.builder()
+            .withName("vw") // Taking value as virtual warehouse name
             .withType(SettingType.UTF_8)
             .build();
 

--- a/driver/src/main/java/com/bytedance/bytehouse/stream/ByteHouseQueryResult.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/stream/ByteHouseQueryResult.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/stream/InputFormat.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/stream/InputFormat.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/stream/NativeInputFormat.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/stream/NativeInputFormat.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/stream/QueryResult.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/stream/QueryResult.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/stream/QueryResultBuilder.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/stream/QueryResultBuilder.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/stream/ValuesNativeInputFormat.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/stream/ValuesNativeInputFormat.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/com/bytedance/bytehouse/stream/ValuesWithParametersNativeInputFormat.java
+++ b/driver/src/main/java/com/bytedance/bytehouse/stream/ValuesWithParametersNativeInputFormat.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/examples/BytehouseQuerySerializeUtils.java
+++ b/driver/src/main/java/examples/BytehouseQuerySerializeUtils.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/examples/BytehouseQuerySerializeUtils.java
+++ b/driver/src/main/java/examples/BytehouseQuerySerializeUtils.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package examples;
+
+import com.bytedance.bytehouse.jdbc.ByteHouseDriver;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.List;
+import java.util.Map;
+import java.util.LinkedHashMap;
+import java.util.ArrayList;
+
+public class BytehouseQuerySerializeUtils {
+
+    public static void main(String[] args) throws Exception {
+
+        final Properties properties = new Properties();
+
+        final String url = "jdbc:bytehouse:///?region=AP-SOUTHEAST-1";
+
+        final ByteHouseDriver driver = new ByteHouseDriver();
+        Connection connection = driver.connect(url, properties);
+
+        createDatabase(connection);
+        createTable(connection);
+        getAndSerialize(connection);
+        dropDatabase(connection);
+    }
+
+    public static void createDatabase(Connection connection) {
+        final String sql = "CREATE DATABASE IF NOT EXISTS test_hieu";
+        System.out.println(sql);
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(sql);
+        } catch (SQLException ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    public static void dropDatabase(Connection connection) {
+        final String sql = "DROP DATABASE test_hieu";
+        System.out.println(sql);
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(sql);
+        } catch (SQLException ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    public static void createTable(Connection connection) {
+        try (Statement stmt = connection.createStatement()) {
+            final String sql = "CREATE TABLE IF NOT EXISTS test_hieu.orders_test (" +
+                    " Arr8 Array(UInt8), " +
+                    " OrderID String, " +
+                    " OrderName String, " +
+                    " OrderPriority Int8 " +
+                    " ) " +
+                    " engine = CnchMergeTree()" +
+                    " partition by OrderID" +
+                    " order by OrderID";
+            System.out.println(sql);
+            stmt.execute(sql);
+        } catch (SQLException ex) {
+            ex.printStackTrace();
+        }
+    }
+
+
+    public static void getAndSerialize(Connection connection) {
+        final String sql = "SELECT * FROM test_hieu.orders3";
+        System.out.println(sql);
+        try (Statement stmt = connection.createStatement()) {
+            ResultSet rs = stmt.executeQuery(sql);
+            List<Map<String, Object>> rows = getResult(rs);
+            System.out.println(rows);
+            RawResult rawResult = new RawResult();
+            rawResult.rows = rows;
+            System.out.println(serialize(rawResult));
+        } catch (SQLException ex) {
+            ex.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static List<Map<String, Object>> getResult(ResultSet resultSet) throws SQLException {
+        List<Map<String, Object>> result = new ArrayList();
+        if (resultSet == null) {
+            return result;
+        } else {
+            ResultSetMetaData metaData = resultSet.getMetaData();
+            int columnCount = metaData.getColumnCount();
+            String[] columnNames = new String[columnCount];
+
+            for (int i = 0; i < columnCount; ++i) {
+                columnNames[i] = metaData.getColumnName(i + 1);
+            }
+
+            while (resultSet.next()) {
+                Map<String, Object> map = new LinkedHashMap();
+
+                for (int i = 0; i < columnCount; ++i) {
+                    map.put(columnNames[i], resultSet.getObject(i + 1));
+                }
+
+                result.add(map);
+            }
+
+            return result;
+        }
+    }
+
+    public static byte[] serialize(RawResult rawResult) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream out = null;
+        try {
+            ObjectOutputStream objectOutputStream
+                    = new ObjectOutputStream(bos);
+            objectOutputStream.writeObject(rawResult);
+            objectOutputStream.flush();
+            byte[] yourBytes = bos.toByteArray();
+            return yourBytes;
+        } finally {
+            try {
+                if (out != null) {
+                    out.close();
+                }
+                bos.close();
+            } catch (IOException ex) {
+                // ignore close exception
+            }
+        }
+    }
+
+}

--- a/driver/src/main/java/examples/BytehouseQuerySerializeUtils.java
+++ b/driver/src/main/java/examples/BytehouseQuerySerializeUtils.java
@@ -47,11 +47,11 @@ public class BytehouseQuerySerializeUtils {
         final ByteHouseDriver driver = new ByteHouseDriver();
         Connection connection = driver.connect(url, properties);
 
+        dropDatabase(connection);
         createDatabase(connection);
         createTable(connection);
         insertTable(connection);
         getAndSerialize(connection);
-        dropDatabase(connection);
     }
 
     public static void createDatabase(Connection connection) {
@@ -65,7 +65,7 @@ public class BytehouseQuerySerializeUtils {
     }
 
     public static void dropDatabase(Connection connection) {
-        final String sql = "DROP DATABASE test_hieu";
+        final String sql = "DROP DATABASE IF EXISTS test_hieu";
         System.out.println(sql);
         try (Statement stmt = connection.createStatement()) {
             stmt.execute(sql);
@@ -81,7 +81,7 @@ public class BytehouseQuerySerializeUtils {
                     " Arr9 Array(FixedString(10)), " +
                     " OrderID FixedString(10), " +
                     " OrderName String, " +
-                    " OrderPriority Int8 " +
+                    " OrderPriority UInt64 " +
                     " ) " +
                     " engine = CnchMergeTree()" +
                     " partition by OrderID" +
@@ -98,7 +98,7 @@ public class BytehouseQuerySerializeUtils {
             final String sql = "INSERT INTO test_hieu.orders_test "
                     + " (Arr8, Arr9, OrderID, OrderName, OrderPriority) "
                     + " VALUES "
-                    + " (['1', '2'], ['3', '4'], '1', 'Apple', 1) ";
+                    + " (['1', '2'], ['3', '4'], '1', 'Apple', 10672915355300043251) ";
             System.out.println(sql);
             stmt.executeUpdate(sql);
         } catch (SQLException ex) {

--- a/driver/src/main/java/examples/Main.java
+++ b/driver/src/main/java/examples/Main.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/examples/RawResult.java
+++ b/driver/src/main/java/examples/RawResult.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/main/java/examples/RawResult.java
+++ b/driver/src/main/java/examples/RawResult.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package examples;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+public class RawResult implements Serializable, Cloneable {
+
+    private static final long serialVersionUID = -8100901408985165226L;
+
+    private List<String> headers;
+
+    public List<Map<String, Object>> rows;
+
+    private String errorMessage;
+
+    private Long executeTime;
+
+    private Integer rawIndex;
+
+    private Map<String, Object> extraParameters;
+}

--- a/driver/src/test/java/com/bytedance/bytehouse/buffer/CompressedBuffedReaderTest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/buffer/CompressedBuffedReaderTest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/buffer/SocketBuffedReaderTest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/buffer/SocketBuffedReaderTest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/AbstractITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/AbstractITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/BatchInsertITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/BatchInsertITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseArrayITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseArrayITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseConfigITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseConfigITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseConnectionITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseConnectionITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseDataSourceTest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseDataSourceTest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseDatabaseMetaDataITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseDatabaseMetaDataITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseDatabaseMetaDataITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseDatabaseMetaDataITest.java
@@ -65,9 +65,9 @@ public class ByteHouseDatabaseMetaDataITest extends AbstractITest {
                 ResultSet columns = dm.getColumns(null, databaseName, tableName, null);
                 assertTrue(columns.next());
                 assertEquals(columns.getString("TABLE_CAT"), "default");
-                assertEquals(columns.getString("TABLE_SCHEM"), databaseName.toLowerCase());
-                assertEquals(columns.getString("TABLE_NAME"), tableName.toLowerCase());
-                assertEquals(columns.getString("COLUMN_NAME"), "colString".toLowerCase());
+                assertEquals(columns.getString("TABLE_SCHEM"), databaseName.toUpperCase());
+                assertEquals(columns.getString("TABLE_NAME"), tableName.toUpperCase());
+                assertEquals(columns.getString("COLUMN_NAME"), "colString");
                 assertEquals(columns.getInt("DATA_TYPE"), Types.VARCHAR);
                 assertEquals(columns.getString("TYPE_NAME"), "String");
                 assertEquals(columns.getInt("COLUMN_SIZE"), 0);
@@ -90,9 +90,9 @@ public class ByteHouseDatabaseMetaDataITest extends AbstractITest {
                 assertEquals(columns.getString("IS_GENERATEDCOLUMN"), "NO");
                 assertTrue(columns.next());
                 assertEquals(columns.getString("TABLE_CAT"), "default");
-                assertEquals(columns.getString("TABLE_SCHEM"), databaseName.toLowerCase());
-                assertEquals(columns.getString("TABLE_NAME"), tableName.toLowerCase());
-                assertEquals(columns.getString("COLUMN_NAME"), "colInt".toLowerCase());
+                assertEquals(columns.getString("TABLE_SCHEM"), databaseName.toUpperCase());
+                assertEquals(columns.getString("TABLE_NAME"), tableName.toUpperCase());
+                assertEquals(columns.getString("COLUMN_NAME"), "colInt");
                 assertEquals(columns.getInt("DATA_TYPE"), Types.INTEGER);
                 assertEquals(columns.getString("TYPE_NAME"), "Int32");
                 assertEquals(columns.getInt("COLUMN_SIZE"), 11);
@@ -115,9 +115,9 @@ public class ByteHouseDatabaseMetaDataITest extends AbstractITest {
                 assertEquals(columns.getString("IS_GENERATEDCOLUMN"), "NO");
                 assertTrue(columns.next());
                 assertEquals(columns.getString("TABLE_CAT"), "default");
-                assertEquals(columns.getString("TABLE_SCHEM"), databaseName.toLowerCase());
-                assertEquals(columns.getString("TABLE_NAME"), tableName.toLowerCase());
-                assertEquals(columns.getString("COLUMN_NAME"), "colFloat".toLowerCase());
+                assertEquals(columns.getString("TABLE_SCHEM"), databaseName.toUpperCase());
+                assertEquals(columns.getString("TABLE_NAME"), tableName.toUpperCase());
+                assertEquals(columns.getString("COLUMN_NAME"), "colFloat");
                 assertEquals(columns.getInt("DATA_TYPE"), Types.FLOAT);
                 assertEquals(columns.getString("TYPE_NAME"), "Nullable(Float32)");
                 assertEquals(columns.getInt("COLUMN_SIZE"), 0);

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseDriverRegisterTest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseDriverRegisterTest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseJdbcUrlParserITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseJdbcUrlParserITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseLowCardinalityITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseLowCardinalityITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseResultSetBuilderITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseResultSetBuilderITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseResultSetMetaDataITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseResultSetMetaDataITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseSQLExceptionITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseSQLExceptionITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseSQLExceptionITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseSQLExceptionITest.java
@@ -30,7 +30,7 @@ public class ByteHouseSQLExceptionITest extends AbstractITest {
                 statement.executeQuery("DROP TABLE test");
             } catch (SQLException e) {
                 assertTrue(e instanceof ByteHouseSQLException);
-                assertEquals(0, e.getErrorCode()); // gateway default error code
+                assertEquals(81, e.getErrorCode()); // gateway default error code
                 assertEquals(e.getErrorCode(), e.getErrorCode());
             }
         });

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseSettingsITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseSettingsITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseSystemDatabaseMetadataITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/ByteHouseSystemDatabaseMetadataITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/ConcurrencyITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/ConcurrencyITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/ConnectionParamITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/ConnectionParamITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/DataTypeConversionITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/DataTypeConversionITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/DataTypesITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/DataTypesITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/GatewayConnectionITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/GatewayConnectionITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/InsertComplexTypeITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/InsertComplexTypeITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/InsertComplexTypeITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/InsertComplexTypeITest.java
@@ -26,6 +26,31 @@ import org.junit.jupiter.api.Test;
 public class InsertComplexTypeITest extends AbstractITest {
 
     @Test
+    public void successfullyNullableArrayDataType() throws Exception {
+        withStatement(statement -> {
+            String databaseName = getDatabaseName();
+            String tableName = databaseName + "." + getTableName();
+
+            try {
+                statement.execute(String.format("CREATE DATABASE %s", databaseName));
+                statement.execute(String.format("CREATE TABLE %s(timestamp Nullable(Datetime), "
+                        + "brand Nullable(String), user_id String, order_id String, price Decimal(20, 2),"
+                        + " discount Decimal(20, 2), withdraw_pirce Decimal(20, 2), order_type Nullable(String),"
+                        + " activity_type Nullable(String), user_type Nullable(Array(String)), "
+                        + "user_level Nullable(String), store Nullable(String))"
+                        + " ENGINE=CnchMergeTree() order by tuple()", tableName));
+
+                statement.execute(String.format("INSERT INTO %s VALUES ('2022-10-13 12:12:12', "
+                        + "'ylo', '1', '2', 0.1, 0.2, 0.3, 'order1', '22', ['1', '1', '0', '0'], "
+                        + "'level', 'hello')", tableName));
+            }
+            finally {
+                statement.execute(String.format("DROP DATABASE %s", databaseName));
+            }
+        });
+    }
+
+    @Test
     public void successfullyArrayDataType() throws Exception {
         withStatement(statement -> {
             String databaseName = getDatabaseName();

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/InsertSimpleTypeITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/InsertSimpleTypeITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/IssueReproduceITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/IssueReproduceITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/PreparedStatementITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/PreparedStatementITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/QueryComplexTypeITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/QueryComplexTypeITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/QuerySimpleTypeITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/QuerySimpleTypeITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/QuerySimultaneousITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/QuerySimultaneousITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/ResultSetMetadataITest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/ResultSetMetadataITest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/SQLLexerTest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/SQLLexerTest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/tool/EmbeddedDriver.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/tool/EmbeddedDriver.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/tool/FragmentBuffedReader.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/tool/FragmentBuffedReader.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/jdbc/tool/TestHarness.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/jdbc/tool/TestHarness.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/log/JdkLoggerTest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/log/JdkLoggerTest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/log/LoggerFactoryUtilsTest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/log/LoggerFactoryUtilsTest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/log/MessageFormatterTest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/log/MessageFormatterTest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/misc/CollectionInternalUtilsTest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/misc/CollectionInternalUtilsTest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/misc/PrimitveConverterTest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/misc/PrimitveConverterTest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/misc/SQLParserUtilsTest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/misc/SQLParserUtilsTest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/settings/ByteHouseConfigTest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/settings/ByteHouseConfigTest.java
@@ -1,4 +1,6 @@
 /*
+ * This file may have been modified by ByteDance Ltd. and/or its affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/driver/src/test/java/com/bytedance/bytehouse/settings/ByteHouseConfigTest.java
+++ b/driver/src/test/java/com/bytedance/bytehouse/settings/ByteHouseConfigTest.java
@@ -162,7 +162,7 @@ class ByteHouseConfigTest {
     @Test
     public void testVolcanoEngineConfig() {
         ByteHouseConfig volcanoConfig = ByteHouseConfig.Builder.builder()
-                .region("CN_BEIJING")
+                .region("CN-BEIJING")
                 .secure(true)
                 .isVolcano(true)
                 .accessKey("ACCESS_KEY")


### PR DESCRIPTION
```markdown
### Added
- Support API Key authentication
- Support Show ByteHouse table keys
- Add virtual warehouse name settings

### Changed
- Upgrade JWT version to v3.19.2
- Refactor serializable character set
- Update Volcano region name to CN-BEIJING
- Update License header to include claims

### Fixed
- Fix Datatype serialization issues
- Fix UInt64 lexer for parsing
- Fix insertion query for Nullable array datatype
```